### PR TITLE
Restrict board access for Spymaster and players that are not their turn

### DIFF
--- a/client/src/pages/game/Card.js
+++ b/client/src/pages/game/Card.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import { Button, Typography } from "@material-ui/core";
 
@@ -10,16 +10,28 @@ const useStyles = makeStyles({
   },
 });
 
-function Card() {
+function Card({ onClick, isActive }) {
   const classes = useStyles();
+  const [style, setStyle] = useState("");
+
+  useEffect(() => {
+    if (!isActive) {
+      const style = "non-active";
+      setStyle(style);
+    } else {
+      setStyle("");
+    }
+  });
 
   return (
     <Button
-      className="card"
+      className={`card ${style}`}
       variant="outlined"
       disableRipple
+      disableFocusRipple
       fullWidth
       classes={{ label: classes.button }}
+      onClick={onClick}
     >
       <Typography variant="h6">Card</Typography>
     </Button>

--- a/client/src/pages/game/Card.js
+++ b/client/src/pages/game/Card.js
@@ -21,7 +21,7 @@ function Card({ onClick, isActive }) {
     } else {
       setStyle("");
     }
-  });
+  }, [isActive]);
 
   return (
     <Button

--- a/client/src/pages/game/Game.css
+++ b/client/src/pages/game/Game.css
@@ -28,6 +28,11 @@
   color: white;
 }
 
+.gameboard .card.non-active:hover {
+  background-color: white;
+  cursor: default;
+}
+
 .gameboard .card.selected.red {
   background-color: #f86155;
 }

--- a/client/src/pages/game/Game.js
+++ b/client/src/pages/game/Game.js
@@ -28,13 +28,11 @@ function Game(props) {
     const matchId = props.location.state
       ? props.location.state.matchId
       : "ASDF"; // dummy data
-    const user = props.location.state
-      ? props.location.state.user
-      : { id: "1234", name: "Tony" }; // dummy data
-    const role = props.location.state ? props.location.state.role : "Spymaster"; // dummy data
-    const player = { user, role };
+    const player = props.location.state
+      ? props.location.state.player
+      : { user: { id: "1234", name: "Tony" }, team: "Red", role: "Spymaster" }; // dummy data
 
-    if (matchId && user) {
+    if (matchId && player) {
       setMatchId(matchId);
       setPlayer(player);
     } else {

--- a/client/src/pages/game/Game.js
+++ b/client/src/pages/game/Game.js
@@ -60,7 +60,7 @@ function Game(props) {
               <GamePrompt gameState={gameState} />
             </Grid>
             <Grid item>
-              <GameBoard />
+              <GameBoard gameState={gameState} player={player} />
             </Grid>
           </Grid>
         </Grid>

--- a/client/src/pages/game/Game.js
+++ b/client/src/pages/game/Game.js
@@ -4,12 +4,9 @@ import Container from "@material-ui/core/Container";
 import Grid from "@material-ui/core/Grid";
 
 import { AppContext } from "../../App";
-import { useGameState } from "../../socket_io/GameIO";
 import GamePrompt from "./GamePrompt";
 import GameBoard from "./GameBoard";
 import Chat from "../chat/Chat";
-
-import GameIO from "../../socket_io/GameIO";
 import "./Game.css";
 
 function Game(props) {
@@ -17,6 +14,7 @@ function Game(props) {
   const [matchId, setMatchId] = useState(
     props.location.state ? props.location.state.matchId : ""
   );
+  // TODO: get player data from resolve game start event after roles are assigned
   const [player, setPlayer] = useState({
     user: props.location.state ? props.location.state.user : null,
     team: "Red",

--- a/client/src/pages/game/GameBoard.js
+++ b/client/src/pages/game/GameBoard.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { GridList, GridListTile, Container } from "@material-ui/core";
 
 import Card from "./Card";
@@ -28,6 +28,20 @@ function GameBoard() {
       </GridList>
     </Container>
   );
+}
+
+function useBoardStatus({ gameState, player }) {
+  const [canPerformActions, setCanPerformActions] = useState(false);
+
+  useEffect(() => {
+    if (gameState) {
+      if (player.team === gameState.gameTurn.team) {
+        setCanPerformActions(true);
+      }
+    }
+  }, [gameState, player.team]);
+
+  return canPerformActions;
 }
 
 export default GameBoard;

--- a/client/src/pages/game/GameBoard.js
+++ b/client/src/pages/game/GameBoard.js
@@ -51,7 +51,7 @@ function useBoardStatus(gameState, player) {
         setCanPerformActions(true);
       }
     }
-  });
+  }, [gameState, player.team, player.role]);
 
   return canPerformActions;
 }

--- a/client/src/pages/game/GameBoard.js
+++ b/client/src/pages/game/GameBoard.js
@@ -2,17 +2,26 @@ import React, { useState, useEffect } from "react";
 import { GridList, GridListTile, Container } from "@material-ui/core";
 
 import Card from "./Card";
+import { TEAM_ROLE } from "../game_lobby/team_select/TeamPresets";
 
 const MAX_BOARD_CARDS = 25;
 
-function GameBoard() {
+function GameBoard({ gameState, player }) {
+  const canPerformActions = useBoardStatus(gameState, player);
+
+  const selectCard = () => {
+    if (canPerformActions) {
+      console.log("card selected on board");
+    }
+  };
+
   const generateCards = () => {
     let result = [];
 
     for (let index = 0; index < MAX_BOARD_CARDS; index++) {
       const element = (
         <GridListTile key={index}>
-          <Card />
+          <Card onClick={selectCard} isActive={canPerformActions} />
         </GridListTile>
       );
       result.push(element);
@@ -30,16 +39,19 @@ function GameBoard() {
   );
 }
 
-function useBoardStatus({ gameState, player }) {
+function useBoardStatus(gameState, player) {
   const [canPerformActions, setCanPerformActions] = useState(false);
 
   useEffect(() => {
     if (gameState) {
-      if (player.team === gameState.gameTurn.team) {
+      if (
+        player.team === gameState.gameTurn.team &&
+        player.role === TEAM_ROLE.FIELD_AGENT
+      ) {
         setCanPerformActions(true);
       }
     }
-  }, [gameState, player.team]);
+  });
 
   return canPerformActions;
 }

--- a/client/src/pages/game/GamePrompt.js
+++ b/client/src/pages/game/GamePrompt.js
@@ -1,10 +1,8 @@
-import React, { useState } from "react";
+import React from "react";
 import { Box, Container, Grid, Typography } from "@material-ui/core";
 import TimerIcon from "@material-ui/icons/Timer";
 
 function GamePrompt({ gameState }) {
-  const [timer, setTimer] = useState(45);
-
   return (
     <Container>
       <Grid container justify="space-between" alignItems="center">
@@ -14,7 +12,7 @@ function GamePrompt({ gameState }) {
               <TimerIcon fontSize="large" />
             </Grid>
             <Grid item>
-              <Typography variant="h5">{timer}s left</Typography>
+              <Typography variant="h5">30s left</Typography>
             </Grid>
           </Grid>
         </Grid>

--- a/client/src/pages/game_lobby/GameLobby.js
+++ b/client/src/pages/game_lobby/GameLobby.js
@@ -26,6 +26,7 @@ function GameLobby(props) {
     } else {
       props.history.push({ pathname: "/" });
     }
+    // eslint-disable-next-line
   }, []);
 
   const isTeamReady = (team) => {

--- a/client/src/pages/game_lobby/GameLobby.js
+++ b/client/src/pages/game_lobby/GameLobby.js
@@ -10,7 +10,6 @@ import Header from "../common/Header";
 import TeamSelect from "./team_select/TeamSelect";
 
 import { AppContext } from "../../App";
-
 import "../common/common.css";
 import "./GameLobby.css";
 
@@ -18,7 +17,7 @@ const SPYMASTER_INDEX = 0;
 const FIELD_AGENT_INDEX = 1;
 
 function GameLobby(props) {
-  const { user } = useUser(); // will be used as player's data (i.e. id and name)
+  const { user } = useUser();
   const [matchId, setMatchId] = useState(null);
   const [canStartGame, setCanStartGame] = useState(false);
 
@@ -54,7 +53,7 @@ function GameLobby(props) {
       gameIO.state.io.on("start turn", (gameState) => {
         props.history.push({
           pathname: "/game",
-          state: { gameState: gameState, matchId: matchId, user: user },
+          state: { gameState, matchId, user: user },
         });
       });
       console.log("Game is starting...");

--- a/client/src/pages/game_lobby/team_select/TeamPresets.js
+++ b/client/src/pages/game_lobby/team_select/TeamPresets.js
@@ -3,11 +3,23 @@ export const TEAM_CODE = {
   BLUE: "Blue",
 };
 
-export const DEFAULT_TEAM_STATE = [
-  { role: "Spymaster", player: null },
-  { role: "Field Agent", player: null },
-  { role: "Field Agent", player: null },
-  { role: "Field Agent", player: null },
+export const TEAM_ROLE = {
+  SPYMASTER: "Spymaster",
+  FIELD_AGENT: "Field Agent",
+};
+
+export const DEFAULT_RED_TEAM_STATE = [
+  { team: TEAM_CODE.RED, role: TEAM_ROLE.SPYMASTER, player: null },
+  { team: TEAM_CODE.RED, role: TEAM_ROLE.FIELD_AGENT, player: null },
+  { team: TEAM_CODE.RED, role: TEAM_ROLE.FIELD_AGENT, player: null },
+  { team: TEAM_CODE.RED, role: TEAM_ROLE.FIELD_AGENT, player: null },
+];
+
+export const DEFAULT_BLUE_TEAM_STATE = [
+  { team: TEAM_CODE.BLUE, role: TEAM_ROLE.SPYMASTER, player: null },
+  { team: TEAM_CODE.BLUE, role: TEAM_ROLE.FIELD_AGENT, player: null },
+  { team: TEAM_CODE.BLUE, role: TEAM_ROLE.FIELD_AGENT, player: null },
+  { team: TEAM_CODE.BLUE, role: TEAM_ROLE.FIELD_AGENT, player: null },
 ];
 
 export const ACTION_TYPE = {

--- a/client/src/pages/game_lobby/team_select/TeamSelect.js
+++ b/client/src/pages/game_lobby/team_select/TeamSelect.js
@@ -9,15 +9,13 @@ import Typography from "@material-ui/core/Typography";
 import {
   TEAM_CODE,
   ACTION_TYPE,
-  DEFAULT_TEAM_STATE,
+  DEFAULT_RED_TEAM_STATE,
+  DEFAULT_BLUE_TEAM_STATE,
   reducer as teamReducer,
 } from "./TeamPresets";
 import { JoinRoleAction, LeaveRoleAction } from "./TeamSelectActions";
 import "./TeamSelect.css";
 import "../../common/common.css";
-
-const DEFAULT_RED_TEAM_STATE = JSON.parse(JSON.stringify(DEFAULT_TEAM_STATE));
-const DEFAULT_BLUE_TEAM_STATE = JSON.parse(JSON.stringify(DEFAULT_TEAM_STATE));
 
 const UNOCCUPIED_SPOT_NAME = "--";
 


### PR DESCRIPTION
**NEW**
Added a flag and css to restrict actions on the board depending on team turn and role. No Spymasters cannot interact with the board (no cursor or transparent highlight on card hover), only Field Masters if it's their team's turn.

#42 